### PR TITLE
Ep review - Rereference LRP & Compute stimulus-locked BC

### DIFF
--- a/Step_Functions/Epoching_Tasks/Bad_Epochs.m
+++ b/Step_Functions/Epoching_Tasks/Bad_Epochs.m
@@ -70,14 +70,18 @@ try % For Error Handling, all steps are positioned in a try loop to capture erro
                     
 
                 elseif AnalysisName == "Flanker_MVPA" 
-                    Event_Window = [-0.300 0.300]; % Epoch length in seconds
-                    Relevant_Triggers = [ 106, 116, 126,  136, ...
-                        107, 117, 127, 137, 108, 118, 128, 138, ...
-                        109, 119, 129, 139  ]; %Responses Experimenter Absent
+                      Event_Window = [-0.200 1.150]; % Epoch length in seconds (stimulus-locked)
+                      Relevant_Triggers = [ 104, 114, 124, 134 ]; %Target Onset Experimenter Absent
+%                     Event_Window = [-0.300 0.300]; % Epoch length in seconds
+%                     Relevant_Triggers = [ 106, 116, 126,  136, ...
+%                         107, 117, 127, 137, 108, 118, 128, 138, ...
+%                         109, 119, 129, 139  ]; %Responses Experimenter Absent
                     
                 elseif AnalysisName == "GoNoGo_MVPA" 
-                    Event_Window = [-0.300 0.300]; % Epoch length in seconds
-                    Relevant_Triggers = [211, 220 ]; %Responses Speed/Acc emphasis
+                      Event_Window = [-0.200 1.150]; % Epoch length in seconds (stimulus-locked)
+                      Relevant_Triggers = [201, 202 ]; %Target Onset Speed/Accuracy
+%                     Event_Window = [-0.300 0.300]; % Epoch length in seconds
+%                     Relevant_Triggers = [211, 220 ]; %Responses Speed/Acc emphasis
 
                 elseif AnalysisName == "Flanker_GMA" || AnalysisName == "Flanker_Perfectionism" 
                     Event_Window = [-0.500 0.800]; % Epoch length in seconds

--- a/Step_Functions/Preprocessing_All/Epoching_AC.m
+++ b/Step_Functions/Preprocessing_All/Epoching_AC.m
@@ -75,14 +75,18 @@ try % For Error Handling, all steps are positioned in a try loop to capture erro
                 
 
             elseif AnalysisName == "Flanker_MVPA" 
-                  Event_Window = [-0.300 0.300]; % Epoch length in seconds
-                  Relevant_Triggers = [ 106, 116, 126,  136, ...
-                      107, 117, 127, 137, 108, 118, 128, 138, ...
-                      109, 119, 129, 139  ]; %Responses Experimenter Absent
+                    Event_Window = [-0.200 1.150]; % Epoch length in seconds (stimulus-locked)
+                    Relevant_Triggers = [ 104, 114, 124, 134 ]; %Target Onset Experimenter Absent
+%                   Event_Window = [-0.300 0.300]; % Epoch length in seconds
+%                   Relevant_Triggers = [ 106, 116, 126,  136, ...
+%                       107, 117, 127, 137, 108, 118, 128, 138, ...
+%                       109, 119, 129, 139  ]; %Responses Experimenter Absent
 
               elseif AnalysisName == "GoNoGo_MVPA" 
-                  Event_Window = [-0.300 0.300]; % Epoch length in seconds
-                  Relevant_Triggers = [211, 220 ]; %Responses Speed/Acc emphasis
+                    Event_Window = [-0.200 1.150]; % Epoch length in seconds (stimulus-locked)
+                    Relevant_Triggers = [201, 202 ]; %Targets Speed
+%                   Event_Window = [-0.300 0.300]; % Epoch length in seconds
+%                   Relevant_Triggers = [211, 220 ]; %Responses Speed/Acc emphasis
 
               elseif AnalysisName == "Flanker_GMA" || AnalysisName == "Flanker_Perfectionism" 
                   Event_Window = [-0.500 0.800]; % Epoch length in seconds

--- a/Step_Functions/Quantification_MVPA/Electrodes.m
+++ b/Step_Functions/Quantification_MVPA/Electrodes.m
@@ -37,7 +37,14 @@ Conditional = ["NaN", "NaN",  "NaN", "NaN"];
 SaveInterim = logical([0]); 
 Order = [20]; 
 
+% Create EEG substructures from 3d EEGmatrix containing only trials from LRP electrodes (channels x dp x trials)
+chanlocs = struct2table(INPUT.data.LRP.chanlocs);
+Electrodes = upper(strsplit(Choice, ", ")); 
+lrp_chanlocs = [find(strcmp(chanlocs.labels, Electrodes(1))) find(strcmp(chanlocs.labels, Electrodes(2)))]; %only use LRP electrodes of interest
 
+INPUT.data.LRP = pop_select(INPUT.data.LRP, 'channel', lrp_chanlocs); %remove other channels from EEG structure
+
+clear chanlocs lrp_chanlocs
 
 % ****** Updating the OUTPUT structure ******
 % No changes should be made here.

--- a/Step_Functions/Quantification_MVPA/Reference.m
+++ b/Step_Functions/Quantification_MVPA/Reference.m
@@ -93,11 +93,13 @@ function OUTPUT = Reference(INPUT, Choice)
                     EEG = pop_reref(EEG, {EEG.chanlocs(Mastoids).labels}, 'keepref', 'on');
                     LRP = EEG;
                 elseif strcmpi(Choice, "CSD")
-                    LRP = EEG; % Rereference LRP Data never to CSD
+                    % for LRP, we need to rereference data to the Mastoids
+                    LRP = EEG; 
                     Mastoids = find(contains({LRP.chanlocs.labels}, {'MAST'}));
+                    LRP = pop_reref(LRP, {LRP.chanlocs(Mastoids).labels}, 'keepref', 'on'); % Rereference LRP Data never to CSD
                     EEG = pop_select( EEG, 'nochannel',{'VOGabove','VOGbelow','HOGr','HOGl', 'MASTl', 'MASTr'}); 
                     EEG.data = laplacian_perrinX(EEG.data, [EEG.chanlocs.X], [EEG.chanlocs.Y], [EEG.chanlocs.Z]);
-	    		          EEG.data = EEG.data/100;
+	    		    EEG.data = EEG.data/100;
                 end        
           end
         end

--- a/Step_Functions/Quantification_MVPA/Trials_Performance.m
+++ b/Step_Functions/Quantification_MVPA/Trials_Performance.m
@@ -49,20 +49,25 @@ try % For Error Handling, all steps are positioned in a try loop to capture erro
     %### Start Preprocessing Routine                               #######
     %#####################################################################
     if ~strcmp(Choice, "None")
-        Conditions = fieldnames(INPUT.data);
-        for i_cond = 1:length(Conditions)
+
             % Get EEGlab EEG structure from the provided Input Structure
-            EEG = INPUT.data.(Conditions{i_cond});
+            EEG = INPUT.data.EEG;
+            LRP = INPUT.data.LRP;
             
             % Mark Trials with RTs faster than 0.1 and slower than 0.8s
-            IdxKeep = cellfun(@(x)~isempty(x) && x > 0.1 && x <0.8, {EEG.event.RT});
+            IdxKeep_eeg = cellfun(@(x)~isempty(x) && x > 0.1 && x <0.8, {EEG.event.RT});
+            IdxKeep_lrp = cellfun(@(x)~isempty(x) && x > 0.1 && x <0.8, {LRP.event.RT});
             
-            Epochs_to_Keep = {EEG.event.epoch};
-            Epochs_to_Keep = unique([Epochs_to_Keep{IdxKeep}]);
+            Epochs_to_Keep_eeg = {EEG.event.epoch};
+            Epochs_to_Keep_lrp = {LRP.event.epoch};
+
+            Epochs_to_Keep_eeg = unique([Epochs_to_Keep_eeg{IdxKeep_eeg}]);
+            Epochs_to_Keep_lrp = unique([Epochs_to_Keep_lrp{IdxKeep_lrp}]);
             
             % ****** Keep only marked Trials ******
-            EEG = pop_select( EEG, 'trial', Epochs_to_Keep);
-            
+            EEG = pop_select( EEG, 'trial', Epochs_to_Keep_eeg);
+            LRP = pop_select( LRP, 'trial', Epochs_to_Keep_lrp);
+
             %#####################################################################
             %### Wrapping up Preprocessing Routine                         #######
             %#####################################################################
@@ -70,8 +75,9 @@ try % For Error Handling, all steps are positioned in a try loop to capture erro
             % Script creates an OUTPUT structure. Assign here what should be saved
             % and made available for next step. Always save the EEG structure in
             % the OUTPUT.data field, overwriting previous EEG information.
-            OUTPUT.data.(Conditions{i_cond}) = EEG;
-        end
+            OUTPUT.data.EEG = EEG;
+            OUTPUT.data.LRP = LRP;
+  
     end
     
     


### PR DESCRIPTION
- Rereference LRP to Mastoids and store information only for relevant electrodes (code previously lost during last merge)
- Compute stimulus-locked Baseline correction for LRP and EEG data, then response-lock the data