### PR TITLE
update N300H quantification processes and improve ECG/IBI analysis

### DIFF
--- a/Analysis_Functions/ECG2IBI/CECT.m
+++ b/Analysis_Functions/ECG2IBI/CECT.m
@@ -64,6 +64,17 @@ else
         eeg_bins(:,b,:) =...
             squeeze(mean(eeg_bins1(:,eeg_bin_range(b):eeg_bin_range(b+1),:),2));
     end
+    
+    % if only one EEG electrode is selected for CECT analysis, add the
+    % electrode dimension again to the eeg_bins matrix.
+    % The electrode dimension got lost due to the squeeze function
+    % in the previous step 
+    if length(size(eeg_bins)) < 3
+        eeg_bins=eeg_bins';
+        eeg_bins=reshape(eeg_bins, [1, size(eeg_bins,1),  size(eeg_bins,2)]);
+       
+    else
+    end
 
 
     %% Calculate CECTs via within-subject correlations

--- a/Analysis_Functions/ECG2IBI/Rpeaks.m
+++ b/Analysis_Functions/ECG2IBI/Rpeaks.m
@@ -19,7 +19,7 @@ function [peakAmplitude,peakPosition, ECG] = Rpeaks(ECG, min_dis)
 % per second. 
 %
 % - 400 ms corresponds to a maximum heart frequency of 150 beats
-% per second. Seems to work quite well in experimentel settings 
+% per second. Seems to work well in experimentel settings 
 % (i.e., seated participants, no physical exertion)
 %
 % OUTPUT:
@@ -60,23 +60,16 @@ ecg_data_dsm = [NaN ecg_data_dsm];
 % minimum distance criteria for consecutive  peaks
 minpeakdist= ECG.srate/1000*min_dis; 
 
-%% Platzhalter: adaptiven Threshold einbauen (maybe Hilbert envelope?)
-% threshold = nanmean(ecg_data_dsm)/2;
 
 % discard artifactual ECG signal to determine reliable threshold
 artifact_thresh = quantile(ecg_data_dsm, 0.75) + 15*iqr(ecg_data_dsm);
 ecg_outliers = ecg_data_dsm(1,:);
 
-
-% Discard signal 3 seconds before extreme ECG values
-ecg_artifacts=...
-    [find(ecg_outliers > artifact_thresh)-3*ECG.srate ...
-    find(ecg_outliers > artifact_thresh)-ECG.srate + 3*ECG.srate];
+% Detect all extreme values
+ecg_artifacts = find(ecg_outliers > artifact_thresh);
 ecg_artifacts = unique(ecg_artifacts);
 
-% remove potential negative. PB 04.01.24
-ecg_artifacts((ecg_artifacts < 0))=[];
-
+% remove extreme values and calculate threshold
 artifact_free_ecg=ecg_data_dsm;artifact_free_ecg(1,ecg_artifacts)=NaN;
 threshold = mean(artifact_free_ecg,'omitnan');
 

--- a/Analysis_Functions/ECG2IBI/ecg2ibi.m
+++ b/Analysis_Functions/ECG2IBI/ecg2ibi.m
@@ -20,7 +20,7 @@ function ibi = ecg2ibi(ECG, filename, interpolation)
 % (ECG) channel. (EEGlab needs to be on the Matlab pathway).
 %
 % filename = string containing the filename, particpant code, etc.
-% interpolation = 'interpolation' vs. 'no_interpolations'
+% interpolation = 'interpolation' vs. 'no_interpolation'
 %                 'interpolation' -> artifacts are interpolated using linear interpolation 
 %                 'no_interpolation -> Artifacts are deleted and are
 %                 replaced by NaNs. Thus, the IBI signal contains NaN but

--- a/Analysis_Functions/ECG2IBI/residualArtifacts.m
+++ b/Analysis_Functions/ECG2IBI/residualArtifacts.m
@@ -1,19 +1,28 @@
 function [ibi_result, art_inf] = residualArtifacts(ibi, srate, interpolation)
 
-% This function deletes residual artifacts/ extreme IBIvalues that
+% This function deletes unphysiological and residual artifacts/ extreme IBIvalues that
 % are close to already removed artifacts and thus were liekly missed by the algorithm
 % 
 % INPUT:
 % ibi = ibi data 1xN matrix containing contionus IBI data (N = sampling
 % points)
 % srate = sampling rate of the ibi data
-% interpolate = 'interpolatate' vs. 'no_interpolations'
+% interpolate = 'interpolation' vs. 'no_interpolation'
 % no interpolation = artifacts remain as NaNs in the continous data
 %
 % OUTPUT:
 % ibi_results = contains continous ibi data with removed residual artifacts
 % ('no_interpolation') or contionious ibi data with removed residual
 % artifacts and interpolated IBI values ('interpolate'). 
+
+%*************************************
+%% remove unphysiological IBI values
+%*************************************
+% < 25 BPM: >2400ms
+% > 200 BPM: <300ms
+
+unphysArt = ibi < 300 | ibi > 2400;
+ibi(1,unphysArt) = NaN;
 
 %*************************************
 %% mark detected artifacts in IBI data
@@ -34,7 +43,7 @@ nanIslands = [startIslands; endIslands]';
 %% Remove extreme values around artifacts
 %****************************************
 
-% define buffer size, which is used to detect extreme values before and
+% define buffer size which is used to detect extreme values before and
 % after a detected artifact
 buffer = srate*3;
 % initialize output array
@@ -68,10 +77,12 @@ ibi_result(1,outliers) = NaN;
 art_inf.artifacts.number = length(nanIslands);
 art_inf.artifacts.size = nanIslands;
 
+art_inf.percentBadSignal = sum(isnan(ibi_result))/length(ibi_result);
+
 %*******************************************
 %% Linear interpolation of removed artifacts
 %*******************************************
-if strcmp(interpolation, 'interpolate')
+if strcmp(interpolation, 'interpolation')
     % detect artifact caused NaNs
     nanIndices = isnan(ibi_result);
     diffNan = diff([0, nanIndices, 0]);

--- a/Step_Functions/Quantification_N300H/IBI_calculation.m
+++ b/Step_Functions/Quantification_N300H/IBI_calculation.m
@@ -44,6 +44,9 @@ try
     % Update number of channels
     ECG.nbchan = ECG.nbchan + 1;
 
+    % save percentage of bad IBI points
+    OUTPUT.AC.ECG.artifactPercentage = IBI.artifacts.residuals.percentBadSignal;
+    
     % ****** Updating the OUTPUT structure ******
     % No changes should be made here.
     OUTPUT.StepHistory.(StepName) = Choice;

--- a/Step_Functions/Quantification_N300H/Quantification_N300H_for_Multiverse.m
+++ b/Step_Functions/Quantification_N300H/Quantification_N300H_for_Multiverse.m
@@ -56,6 +56,9 @@ try
     NrElectrodes = length(Electrodes);
     ElectrodeIdx = findElectrodeIdx(EEG.chanlocs, Electrodes);
 
+    % Discard non-relevant EEG electrodes
+    EEG = pop_select(EEG, 'channel', ElectrodeIdx);
+
     %% Calculate CECTs
 
     % Define settings for CECT analysis
@@ -82,7 +85,7 @@ try
     % Check if electrodes are averaged before extracting the N300H,
     % i.e. before calculating intra-individual correlations:
     if strcmp(INPUT.StepHistory.Cluster_Electrodes,"cluster")
-        EEG = pop_select(EEG, 'channel', ElectrodeIdx);
+        
         % Calculate average of electrodecluster and save it as channel 1 in
         % EEG.data matrix
         EEG.data(1,:,:) = squeeze(mean(EEG.data,1));
@@ -170,7 +173,7 @@ try
             tmp_data = NaN(1,BinsEEG(2)-BinsEEG(1)+1,BinsIBI(2)-BinsIBI(1)+1);
             tmp_data = (cect.results. ...
                 (Condition_Names{1,c})...
-                (ElectrodeIdx, BinsEEG(1):BinsEEG(2), BinsIBI(1):BinsIBI(2)));
+                (:, BinsEEG(1):BinsEEG(2), BinsIBI(1):BinsIBI(2)));
 
             % Fisher-Z transform CECTs
             tmp_data = atanh(tmp_data);

--- a/Testing_Scripts/Test_Preproc_Erik.m
+++ b/Testing_Scripts/Test_Preproc_Erik.m
@@ -90,11 +90,12 @@ INPUT = Bad_Epochs(INPUT, "FASTER"); %  "FASTER", "Threshold_100", "Threshold_12
 INPUT = Reference(INPUT, "CAV"); %  "CAV"      "Mastoids"  "CSD" 
 INPUT = Baseline(INPUT, "-200 0"); %  "-200 0", "-100 0", 
 
-INPUT = IBI_calculation(INPUT, "no interpolation"); % "no interpolation", interpolation 
+INPUT = IBI_calculation(INPUT, "no_interpolation"); % "no_interpolation", interpolation 
 INPUT = IBI_epoching(INPUT, "-500 0"); % "-500 0"    "firstTP"
 INPUT = ECG_TimeWindow(INPUT, "2000,5000" );  % "2000,5000"    "3500,4000"    "Relative_Group"
 INPUT = TimeWindow(INPUT,  "250,500" ); %  "250,500"    "200,400"    "300,350"    "Relative_Group"
 INPUT = Electrodes(INPUT, "Cz"); % "Cz"    "Fz,FCz,Cz"    "Fcz,Cz"    "FCz"
 INPUT = Cluster_Electrodes(INPUT, "no_cluster"); %    "no_cluster"    "cluster" "no_cluster_butAV"
 INPUT = Trials_MinNumber(INPUT, "51"); %  "51"    "68"
+%INPUT = Quantification_N300H_for_Multiverse(INPUT, "Mean"); % "Mean", "Bins", "Maximum"
 INPUT = Quantification_N300H(INPUT, "Mean"); % "Mean", "Bins", "Maximum"


### PR DESCRIPTION
- Added quantification of the N300H for multiverse analysis in Quantification_N300H_forMultiverse.m, focusing on electrodes of interest (max 3), reducing CECT analysis time by approximately 600 ms.
- Updated analysis criteria in Quantification_N300H.m and Quantification_N300H_forMultiverse.m to only include epochs with "card numbers" 4 & 5 and not further separate positive and negative feedback epochs by magnitude (as preregistered).
- Improved artifact detection in residualArtifacts.m by discarding unphysiological IBI values indicating heart frequencies <25 bpm or >200 bpm.
- Fixed the threshold calculation for R-peak detection in Rpeaks.m to handle large amplitude artifacts in raw ECG data, ensuring accurate adaptive thresholding.